### PR TITLE
Add mediator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+go-log-gossip

--- a/api/configuration.go
+++ b/api/configuration.go
@@ -1,11 +1,16 @@
 package api
 
-type ApiServerConfiguration struct {
-	addr               string
-	channelToOffServer <-chan bool
-	newLogChannel      chan<- string
+import (
+	"context"
+	"sync"
+)
+
+type ServerConfiguration struct {
+	Addr      string
+	Context   context.Context
+	WaitGroup *sync.WaitGroup
 }
 
-func NewApiServerConfiguration(addr string, channelToOffServer <-chan bool, newLogChannel chan<- string) *ApiServerConfiguration {
-	return &ApiServerConfiguration{addr: addr, channelToOffServer: channelToOffServer, newLogChannel: newLogChannel}
+func NewServerConfiguration(addr string, context context.Context, wg *sync.WaitGroup) *ServerConfiguration {
+	return &ServerConfiguration{Addr: addr, Context: context, WaitGroup: wg}
 }

--- a/domain/features/creating_self_log/commands/create_self_log.go
+++ b/domain/features/creating_self_log/commands/create_self_log.go
@@ -1,0 +1,22 @@
+package commands
+
+import (
+	"fmt"
+	"github.com/decentralized-hse/go-log-gossip/domain"
+)
+
+type CreateSelfLogCommand struct {
+	Message string
+}
+
+func (c *CreateSelfLogCommand) String() string {
+	return fmt.Sprintf("CreateSelfLogCommand{%v}", c.Message)
+}
+
+func NewCreateSelfLogCommand(message string) *CreateSelfLogCommand {
+	return &CreateSelfLogCommand{Message: message}
+}
+
+type CreateSelfLogResponse struct {
+	NewLog *domain.Log
+}

--- a/domain/features/creating_self_log/commands/create_self_log_handler.go
+++ b/domain/features/creating_self_log/commands/create_self_log_handler.go
@@ -1,0 +1,22 @@
+package commands
+
+import (
+	"context"
+	"github.com/decentralized-hse/go-log-gossip/storage"
+	"log"
+)
+
+type CreateSelfLogHandler struct {
+	storage storage.LogStorage
+}
+
+func NewCreateSelfLogHandler(storage storage.LogStorage) *CreateSelfLogHandler {
+	return &CreateSelfLogHandler{storage: storage}
+}
+
+func (c *CreateSelfLogHandler) Handle(_ context.Context, command *CreateSelfLogCommand) (response *CreateSelfLogResponse, err error) {
+	log.Printf("Handling create self log handler, %v", command)
+
+	response = &CreateSelfLogResponse{NewLog: nil}
+	return
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module github.com/decentralized-hse/go-log-gossip
 
 go 1.19
+
+require (
+	github.com/ahmetb/go-linq/v3 v3.2.0 // indirect
+	github.com/goccy/go-reflect v1.2.0 // indirect
+	github.com/mehdihadeli/go-mediatr v1.1.9 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/ahmetb/go-linq/v3 v3.2.0 h1:BEuMfp+b59io8g5wYzNoFe9pWPalRklhlhbiU3hYZDE=
+github.com/ahmetb/go-linq/v3 v3.2.0/go.mod h1:haQ3JfOeWK8HpVxMtHHEMPVgBKiYyQ+f1/kLZh/cj9U=
+github.com/goccy/go-reflect v1.2.0 h1:O0T8rZCuNmGXewnATuKYnkL0xm6o8UNOJZd/gOkb9ms=
+github.com/goccy/go-reflect v1.2.0/go.mod h1:n0oYZn8VcV2CkWTxi8B9QjkCoq6GTtCEdfmR66YhFtE=
+github.com/mehdihadeli/go-mediatr v1.1.9 h1:WDbVxuc7j7jEKdeENYB1SSdfJwXsH/pTNbIWuHDwB6o=
+github.com/mehdihadeli/go-mediatr v1.1.9/go.mod h1:lwgZl7qVL/RKomObBblhG3uEte/r4nJDV95Vd+nGrMw=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/main.go
+++ b/main.go
@@ -1,35 +1,56 @@
 package main
 
 import (
+	"context"
 	"github.com/decentralized-hse/go-log-gossip/api"
+	"github.com/decentralized-hse/go-log-gossip/domain/features/creating_self_log/commands"
+	"github.com/mehdihadeli/go-mediatr"
 	"log"
 	"os"
 	"os/signal"
+	"sync"
+)
+
+var (
+	wg          sync.WaitGroup
+	ctx, cancel = context.WithCancel(context.Background())
 )
 
 func main() {
-	stopApiServerChannel := make(chan bool, 1)
-	newLogChannel := make(chan string, 1)
+	initializeMediatr()
 
-	apiServerConfiguration := api.NewApiServerConfiguration(
+	startApiServer()
+
+	registerGracefulShutdown()
+}
+
+func initializeMediatr() {
+	createSelfLogHandler := commands.NewCreateSelfLogHandler(nil)
+	err := mediatr.RegisterRequestHandler[*commands.CreateSelfLogCommand, *commands.CreateSelfLogResponse](createSelfLogHandler)
+	if err != nil {
+		panic("Failed to register CreateSelfLogHandler")
+	}
+}
+
+func startApiServer() {
+	apiServerConfiguration := api.NewServerConfiguration(
 		":5001",
-		stopApiServerChannel,
-		newLogChannel,
+		ctx,
+		&wg,
 	)
 
-	go api.StartApiServer(apiServerConfiguration)
+	wg.Add(1)
+	go api.ServeAPIServer(apiServerConfiguration)
+}
 
+func registerGracefulShutdown() {
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt)
 
-	isNodeAlive := true
-	for isNodeAlive {
-		select {
-		case <-stop:
-			stopApiServerChannel <- true
-			isNodeAlive = false
-		case message := <-newLogChannel:
-			log.Println(message)
-		}
-	}
+	<-stop
+	log.Println("Graceful shutdown. Cancelling all goroutines")
+	cancel()
+
+	log.Println("Send cancel signal, waiting goroutines")
+	wg.Wait()
 }

--- a/storage/in_memory.go
+++ b/storage/in_memory.go
@@ -1,21 +1,21 @@
 package storage
 
-import "github.com/decentralized-hse/go-log-gossip/log"
+import "github.com/decentralized-hse/go-log-gossip/domain"
 
 type InMemoryStorage struct {
-	_logs []*log.Log
+	_logs []*domain.Log
 }
 
-func NewInMemoryStorage(_logs []*log.Log) *InMemoryStorage {
+func NewInMemoryStorage(_logs []*domain.Log) *InMemoryStorage {
 	return &InMemoryStorage{_logs: _logs}
 }
 
-func (storage *InMemoryStorage) Append(log *log.Log) error {
+func (storage *InMemoryStorage) Append(log *domain.Log) error {
 	storage._logs = append(storage._logs, log)
 
 	return nil
 }
 
-func (storage *InMemoryStorage) Load() []*log.Log {
+func (storage *InMemoryStorage) Load() []*domain.Log {
 	return storage._logs
 }


### PR DESCRIPTION
## Добавление mediator (#4)

https://github.com/mehdihadeli/Go-MediatR

Структуру папок взял с [примера из библиотеки](https://github.com/mehdihadeli/Go-MediatR/tree/6f52841a85410630abb36875079ce4b9201b583d/examples).

Правда не совсем понял, в чем прикол делать dto команды, а потом еще просто команду. Я понял, что через dto команды можно назначить поля json, но как-то выглядит странно. Момент, о котором говорю: [create_product_request_dto](https://github.com/mehdihadeli/Go-MediatR/blob/6f52841a85410630abb36875079ce4b9201b583d/examples/cqrs/internal/products/features/creating_product/dtos/create_product_request_dto.go) и [create_product.go](https://github.com/mehdihadeli/Go-MediatR/blob/6f52841a85410630abb36875079ce4b9201b583d/examples/cqrs/internal/products/features/creating_product/commands/create_product.go).

## Добавление graceful shutdown

Почитать про context:
https://habr.com/ru/company/nixys/blog/461723/

Почитать про waitGroup:
https://blog.logrocket.com/concurrency-patterns-golang-waitgroups-goroutines/

Немного пояснения магии с context & waitGroup. Основная цель - сделать так, чтобы при `Ctrl + C` можно было сделать graceful shutdown (закрыть все сокеты и все такое). 

Моменты:
- Создается контекст в глобальной переменной `ctx` в `main.go`. При создании контекст возвращает сам контекст и функцию `cancel`. Если вызвать функцию `cancel()`, то любая горутина, которая ждет сообщения в канале ctx.Done, начнет завершение своего исполнения;
- waitGroup нужен для того, чтобы дождаться, пока все горутины не закончат свое выполнение (wg.Wait()).

Сейчас этим пользуется только `ApiServer`, потом точно такую же схему можно будет использовать для `Gossiper`.